### PR TITLE
Update XRT to build 149.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-xrt (2.20.0) unstable; urgency=medium
+xrt (2.20.0+nmu1) unstable; urgency=medium
 
   * Non-maintainer upload
   * Initial packaging for upstream

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Uploaders: Punit Agrawal <punit@debian.org>,
 	   Nobuhiro Iwamatsu <iwamatsu@debian.org>
 Build-Depends: cmake,
 	debhelper-compat (= 13),
+        dh-python,
 	doxygen [amd64],
 	libboost-filesystem-dev,
 	libboost-program-options-dev,
@@ -20,9 +21,10 @@ Build-Depends: cmake,
 	lsb-release [amd64],
 	ocl-icd-opencl-dev,
 	ocl-icd-dev,
-	pkg-config,
+	pkgconf,
 	protobuf-compiler,
         pybind11-dev,
+        python3-dev,
         rapidjson-dev,
         systemtap-sdt-dev,
         uuid-dev
@@ -35,7 +37,7 @@ Vcs-Browser: https://salsa.debian.org/xilinx-packages-team/xrt
 Package: libxrt1
 Architecture: arm64 amd64
 Multi-Arch: same
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, ${python3:Depends}
 Description: Xilinx Runtime (XRT) - runtime libraries
  Xilinx Runtime library (XRT) is an open-source easy to
  use software stack that facilitates management and usage of

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 CONFIGURE_ARGS = -DCMAKE_BUILD_TYPE=Release -DXRT_NPU=1 -DXRT_UPSTREAM_DEBIAN=1
 
 %:
-	dh $@ --sourcedir=XRT/src
+	dh $@ --with python3 --sourcedir=XRT/src
 
 override_dh_auto_configure:
 	dh_auto_configure -- $(CONFIGURE_ARGS)

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,0 @@
-version=4
-opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/Vitis-AI-$1.tar.gz/,dversionmangle=s/\+dfsg// \
-       https://github.com/Xilinx/XRT/tags .*/v?(\d\S*)\.tar\.gz


### PR DESCRIPTION
Update XRT with requested fixes for disabling CPack when building for upstream.

Fix debian/ metadata files based on trying to silence lintian.

The build of XRT succeeds provided all binary files are removed from the repo:

```
# ELFIO elf examples and .o files
find XRT -type d -name elf_examples -exec /bin/rm -rf {} \;
find XRT -type f -name \*.elf -exec /bin/rm {} \;
# XRT
/bin/rm XRT/src/runtime_src/core/edge/user/test/usertest
```